### PR TITLE
failing commit, no project reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,6 @@ jobs:
   pr_lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: vijaykramesh/pr-lint-action@v2.2
+    - uses: vijaykramesh/pr-lint-action@v2.3
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # PR Lint Action Demo
 
 This repo demonstrates the pr-lint-action github action.  To see it working, create an MR.
+
+In an MR make some changes


### PR DESCRIPTION
this MR fails because the commits, branches, and MR title don't have the right lint references to [ABC-123] or whatever